### PR TITLE
Remove windows build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          # - windows-latest
           - ubuntu-latest
           - macos-latest
 


### PR DESCRIPTION
Temp removal of windows build in CD due to path errors